### PR TITLE
Added anchor without link to internalparsertest

### DIFF
--- a/src/Parser/InternalLinkParser.php
+++ b/src/Parser/InternalLinkParser.php
@@ -25,7 +25,7 @@ class InternalLinkParser implements InlineParserInterface
 
     public function getMatchDefinition(): InlineParserMatch
     {
-        return InlineParserMatch::regex('(?<!!)\\[\\[([^\\]\\|#]+)(?:#([^\\|]+))?(?:\\|([^\\]]+))?\\]\\]');
+        return InlineParserMatch::regex('(?<!!)\\[\\[([^\\]\\|#]+)?(?:#([^\\|]+))?(?:\\|([^\\]]+))?\\]\\]');
     }
 
     public function parse(InlineParserContext $inlineContext): bool
@@ -34,8 +34,8 @@ class InternalLinkParser implements InlineParserInterface
         $subMatches = $inlineContext->getSubMatches();
         $linkName = $subMatches[0];
         $linkAnchor = $subMatches[1] ?? null;
-        $linkText = $subMatches[2] ?? $linkName;
-        $linkUrl = $this->internalLinkResolver->resolve($linkName, $this->fromPath);
+        $linkText = $subMatches[2] ?? $linkName ?: $linkAnchor;
+        $linkUrl = $linkName ? $this->internalLinkResolver->resolve($linkName, $this->fromPath) : '';
         if ($linkAnchor) {
             $linkUrl .= '#' . $linkAnchor;
         }

--- a/src/Parser/InternalLinkParser.php
+++ b/src/Parser/InternalLinkParser.php
@@ -25,7 +25,7 @@ class InternalLinkParser implements InlineParserInterface
 
     public function getMatchDefinition(): InlineParserMatch
     {
-        return InlineParserMatch::regex('(?<!!)\\[\\[([^\\]\\|#]+)?(?:#([^\\|]+))?(?:\\|([^\\]]+))?\\]\\]');
+        return InlineParserMatch::regex('(?<!!)\\[\\[([^\\]\\|#]+)?(?:#([^\\|\\]]+))?(?:\\|([^\\]]+))?\\]\\]');
     }
 
     public function parse(InlineParserContext $inlineContext): bool

--- a/tests/Parser/InternalLinkParserTest.php
+++ b/tests/Parser/InternalLinkParserTest.php
@@ -63,6 +63,16 @@ test('parses internal link', function (string $markdown, string $linkUrl, string
         'path/to/LinkName.html#LinkAnchor',
         'LinkText',
     ],
+    'without link and with anchor and without text' => [
+        '[[#LinkAnchor]]',
+        '#LinkAnchor',
+        'LinkAnchor'
+    ],
+    'without link and with anchor and with text' => [
+        '[[#LinkAnchor|LinkText]]',
+        '#LinkAnchor',
+        'LinkText'
+    ]
 ]);
 
 test('does not parse embeds', function () {

--- a/tests/Parser/InternalLinkParserTest.php
+++ b/tests/Parser/InternalLinkParserTest.php
@@ -86,3 +86,25 @@ test('does not parse embeds', function () {
     $this->assertInstanceOf(Text::class, $child);
     $this->assertSame('![[LinkName]]', $child->getLiteral());
 });
+
+test('parses surrounding text correctly', function () {
+    $engine = getParseEngine(new FakeLinkResolver);
+
+    $block = new Paragraph;
+    $engine->parse('you roll a [[#d12]] and add a bonus', $block);
+
+    /** @var Text $text */
+    $text = $block->firstChild();
+    $this->assertInstanceOf(Text::class, $text);
+    $this->assertSame('you roll a ', $text->getLiteral());
+
+    /** @var Link $link */
+    $link = $text->next();
+    $this->assertInstanceOf(Link::class, $link);
+    $this->assertSame('#d12', $link->getUrl());
+
+    /** @var Text $text */
+    $text = $link->next();
+    $this->assertInstanceOf(Text::class, $text);
+    $this->assertSame(' and add a bonus', $text->getLiteral());
+});

--- a/tests/Parser/InternalLinkParserTest.php
+++ b/tests/Parser/InternalLinkParserTest.php
@@ -72,7 +72,7 @@ test('parses internal link', function (string $markdown, string $linkUrl, string
         '[[#LinkAnchor|LinkText]]',
         '#LinkAnchor',
         'LinkText'
-    ]
+    ],
 ]);
 
 test('does not parse embeds', function () {

--- a/tests/Resolver/InternalLinkResolverTest.php
+++ b/tests/Resolver/InternalLinkResolverTest.php
@@ -14,7 +14,9 @@ test('resolves if attachment exists', function () {
     $linkName = 'LinkName';
     $fileName = $linkName . '.md';
     $filePath = $vaultPath . DIRECTORY_SEPARATOR . $fileName;
-    touch($filePath);
+    if (!touch($filePath)) {
+        return $this->markTestSkipped('Unable to write to ' . $filePath);
+    }
     $resolver = new InternalLinkResolver($vaultPath);
     $resolvedFileName = $linkName . '.html';
     $this->assertSame($resolvedFileName, $resolver->resolve($linkName, $filePath));


### PR DESCRIPTION
Sorry if this is the wrong way to do this, it is my first pull request on a project I don't own.

Basically, the functionality I am looking for is when an internal link only includes the anchor, in the case of [[#anchor]] or [[#anchor|title]] that it creates an anchor link that points to an anchor in the current page. Used in conjunction with League\CommonMark\Extension\HeadingPermalink\HeadingPermalinkExtension it should allow you to link to heading anchors within the page.

I am unsure how to write that myself, so I added the tests that would check for it.